### PR TITLE
Clang format

### DIFF
--- a/.github/workflows/clang-format-checker.sh
+++ b/.github/workflows/clang-format-checker.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# clang-format-checker.sh
+
+# Files are passed as arguments to the script
+FILES="$@"
+
+echo "clang-format version: $(clang-format --version)"
+FORMATTING_ISSUES=0
+for FILE in $FILES; do
+  DIFF_OUTPUT=$(clang-format -style=file "$FILE" | diff "$FILE" -)
+  if [ -z "$DIFF_OUTPUT" ]; then
+    echo "::notice::OK: $FILE is properly formatted."
+  else
+    echo "::error file=$FILE::NOT OK: $FILE needs formatting."
+    echo "Diff for $FILE:"
+    echo "$DIFF_OUTPUT"
+    FORMATTING_ISSUES=1
+  fi
+done
+
+# Exit with 1 if there were formatting issues.
+if [ "$FORMATTING_ISSUES" -ne 0 ]; then
+  exit 1
+fi
+

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -32,5 +32,6 @@ jobs:
       env:
         CPP_FILES: ${{ steps.files-finder.outputs.cpp_files}}
       run: |
+        /usr/bin/clang-format --version
         bash .github/workflows/clang-format-checker.sh $CPP_FILES
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,7 +16,8 @@ jobs:
         chmod +x llvm.sh
         sudo ./llvm.sh 17
         sudo apt install clang-format-17
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-17 100
+        sudo rm /usr/bin/clang-format
+        sudo ln -s /usr/bin/clang-format-17 /usr/bin/clang-format
 
     - name: Check clang-format version
       run: clang-format --version

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,8 +10,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Install clang-format
-      run: sudo apt-get install -y clang-format
+    - name: Manually install latest clang-format
+      run: |
+        bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
     - name: Find C++ source files
       id: files-finder

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,36 +1,35 @@
-name: clang-format codebase
+name: clang-format check
 
-# Run only on source code change
-on:
-  push:
-    paths:
-      - '**.cpp'
-      - '**.h'
-      - '**.cc'
-    branches: [ main ]
+on: [push]
 
 jobs:
-  format-code:
+  check-formatting:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-    - name: Install Clang-Format
-      run: sudo apt-get install clang-format -y
+    - name: Install clang-format
+      run: sudo apt-get install -y clang-format
 
-    - name: Run Clang-Format
-      run: find . -regex '.*\.\(cpp\|h\|cc\)' -exec clang-format -i {} +
-
-    - name: Commit changes
+    - name: Find C++ source files
+      id: files-finder
       run: |
-        git config --global user.name 'github-actions'
-        git config --global user.email 'github-actions@github.com'
-        git add -A  # Add all modified files to the staging area
-        git commit -m "Apply clang-format changes" || echo "No changes to commit"
-        git push origin
+        {
+          echo 'cpp_files<<EOF'
+          echo $(find . -regex '.*\.\(cpp\|cc\|h\|c\)')
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Show found C++ files
+      env:
+        CPP_FILES: ${{ steps.files-finder.outputs.cpp_files}}
+      run: echo "Files found $CPP_FILES"
+
+    - name: Check formatting
+      env:
+        CPP_FILES: ${{ steps.files-finder.outputs.cpp_files}}
+      run: |
+        bash .github/workflows/clang-format-checker.sh $CPP_FILES
+

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,9 +10,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Manually install latest clang-format
+    - name: Install clang-format
       run: |
-        sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+        sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
+        sudo apt update
+        sudo apt install clang-format-17
+
+    - name: Check clang-format version
+      run: clang-format --version
 
     - name: Find C++ source files
       id: files-finder
@@ -32,6 +38,5 @@ jobs:
       env:
         CPP_FILES: ${{ steps.files-finder.outputs.cpp_files}}
       run: |
-        /usr/bin/clang-format --version
         bash .github/workflows/clang-format-checker.sh $CPP_FILES
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,7 +12,7 @@ jobs:
 
     - name: Manually install latest clang-format
       run: |
-        bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+        sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
     - name: Find C++ source files
       id: files-finder

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,7 +16,7 @@ jobs:
         chmod +x llvm.sh
         sudo ./llvm.sh 17
         sudo apt install clang-format-17
-        sudo update-alternatives --install /usr/bin/clang-format gcc /usr/bin/clang-format-17 100
+        sudo update-alternatives --install /usr/bin/clang-format /usr/bin/clang-format-17 100
 
     - name: Check clang-format version
       run: clang-format --version

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,6 +16,7 @@ jobs:
         chmod +x llvm.sh
         sudo ./llvm.sh 17
         sudo apt install clang-format-17
+        sudo update-alternatives --install /usr/bin/clang-format gcc /usr/bin/clang-format-17 100
 
     - name: Check clang-format version
       run: clang-format --version

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,11 +10,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Install clang-format
+    - name: Install clang-format 17
       run: |
-        sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
-        sudo apt update
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 17
         sudo apt install clang-format-17
 
     - name: Check clang-format version

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,7 +16,7 @@ jobs:
         chmod +x llvm.sh
         sudo ./llvm.sh 17
         sudo apt install clang-format-17
-        sudo update-alternatives --install /usr/bin/clang-format /usr/bin/clang-format-17 100
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-17 100
 
     - name: Check clang-format version
       run: clang-format --version

--- a/clang-format.sh
+++ b/clang-format.sh
@@ -1,0 +1,2 @@
+clang-format -style=file -i $(find . -regex '.*\.\(cpp\|cc\|h\|c\)')
+

--- a/include/Board.h
+++ b/include/Board.h
@@ -88,21 +88,26 @@ struct Board
     static constexpr size_t SentinelCastlingIndex      = 4;
 
     static constexpr std::array<uint64_t, KingPosCount> DefaultKingBoards{
-        maxMsbPossible >> ConvertToReversedPos(4), maxMsbPossible >> ConvertToReversedPos(60)};
+        maxMsbPossible >> ConvertToReversedPos(4), maxMsbPossible >> ConvertToReversedPos(60)
+    };
     static constexpr std::array<int, CastlingCount> CastlingNewKingPos{
-        ConvertToReversedPos(6), ConvertToReversedPos(2), ConvertToReversedPos(62), ConvertToReversedPos(58)};
+        ConvertToReversedPos(6), ConvertToReversedPos(2), ConvertToReversedPos(62), ConvertToReversedPos(58)
+    };
 
     static constexpr std::array<uint64_t, CastlingCount> CastlingsRookMaps{1LLU << 7, 1LLU, 1LLU << 63, 1LLU << 56};
 
     static constexpr std::array<uint64_t, CastlingCount> CastlingNewRookMaps{
-        1LLU << 5, 1LLU << 3, 1LLU << 61, 1LLU << 59};
+        1LLU << 5, 1LLU << 3, 1LLU << 61, 1LLU << 59
+    };
 
     static constexpr std::array<uint64_t, CastlingCount> CastlingSensitiveFields{
-        1LLU << 6 | 1LLU << 5, 1LLU << 2 | 1LLU << 3, 1LLU << 61 | 1LLU << 62, 1LLU << 58 | 1LLU << 59};
+        1LLU << 6 | 1LLU << 5, 1LLU << 2 | 1LLU << 3, 1LLU << 61 | 1LLU << 62, 1LLU << 58 | 1LLU << 59
+    };
 
     static constexpr std::array<uint64_t, CastlingCount> CastlingTouchedFields{
         1LLU << 6 | 1LLU << 5, 1LLU << 2 | 1LLU << 3 | 1LLU << 1, 1LLU << 61 | 1LLU << 62,
-        1LLU << 58 | 1LLU << 59 | 1LLU << 57};
+        1LLU << 58 | 1LLU << 59 | 1LLU << 57
+    };
 
     std::bitset<CastlingCount + 1> Castlings{0}; // additional sentinel field
     uint64_t ElPassantField                = maxMsbPossible >> InvalidElPassantField;

--- a/include/Evaluation/BoardEvaluator.h
+++ b/include/Evaluation/BoardEvaluator.h
@@ -327,7 +327,8 @@ class BoardEvaluator
         68,  75,  82,  85,  89,  97,  105, 113, 122, 131, 140, 150, 169, 180, 191, 202, 213, 225, 237, 248,
         260, 272, 283, 295, 307, 319, 330, 342, 354, 366, 377, 389, 401, 412, 424, 436, 448, 459, 471, 483,
         494, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500,
-        500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500};
+        500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500
+    };
 
     // 4x4 mask on the center board used to evaluate center control
     static constexpr uint64_t CenterFieldsMap = []() constexpr
@@ -335,8 +336,7 @@ class BoardEvaluator
         constexpr uint64_t mask = GenMask(0, 63, 8) | GenMask(1, 63, 8) | GenMask(6, 63, 8) | GenMask(7, 63, 8) |
                                   GenMask(0, 8, 1) | GenMask(8, 16, 1) | GenMask(48, 56, 1) | GenMask(56, 64, 1);
         return ~mask;
-    }
-    ();
+    }();
 
     // values used to calculate material value of given board at the mid-game stage
     static constexpr int16_t BasicFigureValues[]{
@@ -382,15 +382,17 @@ class BoardEvaluator
     // Figure-Position bonuses/penalties tables
     // ----------------------------------------------
 
-    static constexpr int16_t BasicBlackPawnPositionValues[]{
-        0,  0,   0,  0, 0,  0,  0,  0,   50,  50, 50, 50, 50, 50, 50, 50, 10, 10, 20, 30, 30,  20,
-        10, 10,  5,  5, 10, 25, 25, 10,  5,   5,  0,  -5, -5, 20, 20, -5, -5, 0,  5,  -5, -10, 0,
-        0,  -10, -5, 5, 10, 15, 15, -20, -20, 15, 15, 10, 0,  0,  0,  0,  0,  0,  0,  0};
+    static constexpr int16_t BasicBlackPawnPositionValues[]{0,   0,  0,  0,   0,  0,  0,   0,  50, 50, 50, 50, 50,
+                                                            50,  50, 50, 10,  10, 20, 30,  30, 20, 10, 10, 5,  5,
+                                                            10,  25, 25, 10,  5,  5,  0,   -5, -5, 20, 20, -5, -5,
+                                                            0,   5,  -5, -10, 0,  0,  -10, -5, 5,  10, 15, 15, -20,
+                                                            -20, 15, 15, 10,  0,  0,  0,   0,  0,  0,  0,  0};
 
     static constexpr int16_t BasicBlackPawnPositionEndValues[]{
         0,  0,  0,  0,  0,   0,   0,   0,   80,  80,  80,  80,  80, 80, 80, 80, 40, 40, 50, 60, 60, 50,
         40, 40, 30, 30, 40,  45,  45,  40,  30,  30,  15,  17,  20, 30, 30, 20, 17, 15, -5, -5, -5, 0,
-        0,  -5, -5, -5, -20, -20, -30, -30, -30, -20, -20, -20, 0,  0,  0,  0,  0,  0,  0,  0};
+        0,  -5, -5, -5, -20, -20, -30, -30, -30, -20, -20, -20, 0,  0,  0,  0,  0,  0,  0,  0
+    };
 
     static constexpr int16_t BasicBlackKnightPositionValues[]{
         -50, -40, -30, -30, -30, -30, -40, -50, -40, -20, 0,   0,   0,   0,   -20, -40, -30, 0,   10,  15,  15, 10,
@@ -404,30 +406,35 @@ class BoardEvaluator
         10,  10,  10,  -10, -10, 5,   0,   0,   0,   0,   5,   -10, -20, -10, -10, -10, -10, -10, -10, -20,
     };
 
-    static constexpr int16_t BasicBlackRookPositionValues[]{
-        0,  0, 0, 0, 0, 0, 0, 0,  5,  10, 10, 10, 10, 10, 10, 5,  -5, 0, 0, 0, 0, 0, 0, -5, -5, 0, 0, 0, 0, 0, 0, -5,
-        -5, 0, 0, 0, 0, 0, 0, -5, -5, 0,  0,  0,  0,  0,  0,  -5, -5, 0, 0, 0, 0, 0, 0, -5, 0,  0, 5, 5, 5, 5, 0, 0};
+    static constexpr int16_t BasicBlackRookPositionValues[]{0,  0, 0, 0, 0, 0, 0, 0,  5,  10, 10, 10, 10, 10, 10, 5,
+                                                            -5, 0, 0, 0, 0, 0, 0, -5, -5, 0,  0,  0,  0,  0,  0,  -5,
+                                                            -5, 0, 0, 0, 0, 0, 0, -5, -5, 0,  0,  0,  0,  0,  0,  -5,
+                                                            -5, 0, 0, 0, 0, 0, 0, -5, 0,  0,  5,  5,  5,  5,  0,  0};
 
     static constexpr int16_t BasicBlackQueenPositionValues[]{
         -110, -110, -110, -110, -110, -110, -110, -110, -80, -80, -80, -80, -80, -80, -80, -80,
         -60,  -60,  -60,  -60,  -60,  -60,  -60,  -60,  -45, -45, -45, -45, -45, -45, -45, -45,
         -20,  -15,  -15,  -15,  -15,  -15,  -15,  -20,  -10, 5,   5,   5,   5,   5,   5,   -10,
-        -10,  15,   15,   15,   15,   15,   15,   -10,  -20, -10, -10, 30,  30,  -10, -10, -20};
+        -10,  15,   15,   15,   15,   15,   15,   -10,  -20, -10, -10, 30,  30,  -10, -10, -20
+    };
 
     static constexpr int16_t BasicBlackQueenEndPositionValues[]{
         -20, -10, -10, -5,  -5,  -10, -10, -20, -10, 0,  0, 0,   0,   0,   0,   -10, -10, 0,   5,   5,  5, 5,
         0,   -10, -5,  0,   5,   5,   5,   5,   0,   -5, 0, 0,   5,   5,   5,   5,   0,   -5,  -10, 5,  5, 5,
-        5,   5,   0,   -10, -10, 0,   5,   0,   0,   0,  0, -10, -20, -10, -10, -5,  -5,  -10, -10, -20};
+        5,   5,   0,   -10, -10, 0,   5,   0,   0,   0,  0, -10, -20, -10, -10, -5,  -5,  -10, -10, -20
+    };
 
     static constexpr int16_t BasicBlackKingPositionValues[]{
         -30, -40, -40, -50, -50, -40, -40, -30, -30, -40, -40, -50, -50, -40, -40, -30, -30, -40, -40, -50, -50, -40,
         -40, -30, -30, -40, -40, -50, -50, -40, -40, -30, -20, -30, -30, -40, -40, -30, -30, -20, -10, -20, -20, -20,
-        -20, -20, -20, -10, 20,  20,  0,   0,   0,   0,   20,  20,  20,  30,  10,  0,   0,   10,  30,  20};
+        -20, -20, -20, -10, 20,  20,  0,   0,   0,   0,   20,  20,  20,  30,  10,  0,   0,   10,  30,  20
+    };
 
     static constexpr int16_t BasicBlackKingEndPositionValues[]{
         -50, -40, -30, -20, -20, -30, -40, -50, -30, -20, -10, 0,   0,   -10, -20, -30, -30, -10, 20,  30,  30, 20,
         -10, -30, -30, -10, 30,  40,  40,  30,  -10, -30, -30, -10, 30,  40,  40,  30,  -10, -30, -30, -10, 20, 30,
-        30,  20,  -10, -30, -30, -30, 0,   0,   0,   0,   -30, -30, -50, -30, -30, -30, -30, -30, -30, -50};
+        30,  20,  -10, -30, -30, -30, 0,   0,   0,   0,   -30, -30, -50, -30, -30, -30, -30, -30, -30, -50
+    };
 
     static constexpr const int16_t *BasicBlackPositionValues[]{
         BasicBlackPawnPositionValues, BasicBlackKnightPositionValues, BasicBlackBishopPositionValues,
@@ -461,8 +468,7 @@ class BoardEvaluator
         }
 
         return arr;
-    }
-    ();
+    }();
 
     // ------------------------------
     // Material table
@@ -887,11 +893,14 @@ void BoardEvaluator::_processFigEval(
     const uint64_t whiteBitMap, const uint64_t blackBitMap
 )
 {
-    const auto [whiteMidEval, whiteEndEval, whiteControlledFields, wKInfo] = EvalProducerT<MapT, NoOp>(
-    )(bd, whitePinnedFigsBitMap, WHITE, blackPawnControlledFieldsBitMap, whiteBitMap, blackBitMap);
+    const auto [whiteMidEval, whiteEndEval, whiteControlledFields, wKInfo] = EvalProducerT<MapT, NoOp>()(
+        bd, whitePinnedFigsBitMap, WHITE, blackPawnControlledFieldsBitMap, whiteBitMap, blackBitMap
+    );
 
-    const auto [blackMidEval, blackEndEval, blackControlledFields, bKInfo] = EvalProducerT<MapT, ConvertToReversedPos>(
-    )(bd, blackPinnedFigsBitMap, BLACK, whitePawnControlledFieldsBitMap, blackBitMap, whiteBitMap);
+    const auto [blackMidEval, blackEndEval, blackControlledFields, bKInfo] =
+        EvalProducerT<MapT, ConvertToReversedPos>()(
+            bd, blackPinnedFigsBitMap, BLACK, whitePawnControlledFieldsBitMap, blackBitMap, whiteBitMap
+        );
 
     out.midgameEval += whiteMidEval - blackMidEval;
     out.endgameEval += blackEndEval - whiteEndEval;

--- a/include/Evaluation/KingSafetyEval.h
+++ b/include/Evaluation/KingSafetyEval.h
@@ -92,8 +92,7 @@ struct KingSafetyEval
         }
 
         return rv;
-    }
-    ();
+    }();
 
     public:
     static constexpr int32_t KingNoShelterPenalty = -50;

--- a/include/Interface/FenTranslator.h
+++ b/include/Interface/FenTranslator.h
@@ -97,10 +97,11 @@ struct FenTranslator
     static constexpr auto StartingPosition = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
     static constexpr Board StartBoard = {
-        .Castlings      = {0b11111                                        },
+        .Castlings      = {0b11111},
         .ElPassantField = Board::InvalidElPassantBitBoard,
         .MovingColor    = WHITE,
-        .BitBoards      = {
+        .BitBoards =
+            {
                            65280LLU, 66LLU,
                            36LLU, 129LLU,
                            8LLU, 16LLU,

--- a/include/MapTypes/FancyMagicBishopMap.h
+++ b/include/MapTypes/FancyMagicBishopMap.h
@@ -107,11 +107,17 @@ constexpr FancyMagicBishopMap::FancyMagicBishopMap()
         _maps[i].InitFullMask();
 
         MoveInitializer(
-            _maps[i], [](const uint64_t n, const int ind) constexpr { return BishopMapGenerator::GenMoves(n, ind); },
-            []([[maybe_unused]] const int, const BishopMapGenerator::MasksT &m) constexpr {
+            _maps[i],
+            [](const uint64_t n, const int ind) constexpr
+            {
+                return BishopMapGenerator::GenMoves(n, ind);
+            },
+            []([[maybe_unused]] const int, const BishopMapGenerator::MasksT &m) constexpr
+            {
                 return BishopMapGenerator::GenPossibleNeighborsWithOverlap(m);
             },
-            [](const uint64_t b, const BishopMapGenerator::MasksT &m) constexpr {
+            [](const uint64_t b, const BishopMapGenerator::MasksT &m) constexpr
+            {
                 return BishopMapGenerator::StripBlockingNeighbors(b, m);
             },
             boardIndex

--- a/include/MapTypes/FancyMagicRookMap.h
+++ b/include/MapTypes/FancyMagicRookMap.h
@@ -108,11 +108,17 @@ constexpr FancyMagicRookMap::FancyMagicRookMap()
         _maps[i].InitFullMask();
 
         MoveInitializer(
-            _maps[i], [](const uint64_t n, const int ind) constexpr { return RookMapGenerator::GenMoves(n, ind); },
-            []([[maybe_unused]] const int, const RookMapGenerator::MasksT &m) constexpr {
+            _maps[i],
+            [](const uint64_t n, const int ind) constexpr
+            {
+                return RookMapGenerator::GenMoves(n, ind);
+            },
+            []([[maybe_unused]] const int, const RookMapGenerator::MasksT &m) constexpr
+            {
                 return RookMapGenerator::GenPossibleNeighborsWithOverlap(m);
             },
-            [](const uint64_t b, const RookMapGenerator::MasksT &m) constexpr {
+            [](const uint64_t b, const RookMapGenerator::MasksT &m) constexpr
+            {
                 return RookMapGenerator::StripBlockingNeighbors(b, m);
             },
             boardIndex

--- a/include/MapTypes/HashFunctions.h
+++ b/include/MapTypes/HashFunctions.h
@@ -60,7 +60,8 @@ template <class RandomGeneratorT = std::mt19937_64> class Fast2PowHashFunction
     void RollParameters()
     {
         static RandomGeneratorT randEngine_64{
-            static_cast<size_t>(std::chrono::steady_clock::now().time_since_epoch().count())};
+            static_cast<size_t>(std::chrono::steady_clock::now().time_since_epoch().count())
+        };
 
         _a = randEngine_64() | static_cast<__uint128_t>(randEngine_64()) << 64;
         _b = randEngine_64() | static_cast<__uint128_t>(randEngine_64()) << 64;
@@ -151,7 +152,8 @@ template <class RandomGeneratorT = std::mt19937_64> class Fast2PowHashFunctionNo
     void RollParameters()
     {
         static RandomGeneratorT randEngine_64{
-            static_cast<size_t>(std::chrono::steady_clock::now().time_since_epoch().count())};
+            static_cast<size_t>(std::chrono::steady_clock::now().time_since_epoch().count())
+        };
 
         _a = randEngine_64() | static_cast<__uint128_t>(randEngine_64()) << 64;
     }
@@ -231,7 +233,8 @@ template <class RandomGeneratorT = std::mt19937_64> class FancyMagicHashFunction
     void RollParameters()
     {
         static RandomGeneratorT randEngine_64{
-            static_cast<size_t>(std::chrono::steady_clock::now().time_since_epoch().count())};
+            static_cast<size_t>(std::chrono::steady_clock::now().time_since_epoch().count())
+        };
 
         _magic = randEngine_64();
     }
@@ -322,7 +325,8 @@ template <bool OptimizeSecondModulo = false, class RandomGeneratorT = std::mt199
     void RollParameters()
     {
         static RandomGeneratorT randEngine_64{
-            static_cast<size_t>(std::chrono::steady_clock::now().time_since_epoch().count())};
+            static_cast<size_t>(std::chrono::steady_clock::now().time_since_epoch().count())
+        };
 
         _a = randEngine_64();
         _b = randEngine_64();

--- a/include/MoveGeneration/FileMap.h
+++ b/include/MoveGeneration/FileMap.h
@@ -51,8 +51,7 @@ struct FileMap
         }
 
         return rv;
-    }
-    ();
+    }();
 
     static constexpr std::array<uint64_t, Board::BitBoardFields> _neigborFiles = []() constexpr
     {
@@ -76,8 +75,7 @@ struct FileMap
         }
 
         return rv;
-    }
-    ();
+    }();
 
     static constexpr std::array<uint64_t, Board::BitBoardFields> _fatFiles = []() constexpr
     {
@@ -94,8 +92,7 @@ struct FileMap
         }
 
         return rv;
-    }
-    ();
+    }();
 
     static constexpr int offset                                                                = 8;
     static constexpr std::array<std::array<uint64_t, Board::BitBoardFields>, 2> _frontFatFiles = []() constexpr
@@ -132,8 +129,7 @@ struct FileMap
         }
 
         return rv;
-    }
-    ();
+    }();
 
     static constexpr std::array<std::array<uint64_t, Board::BitBoardFields>, 2> _frontFiles = []() constexpr
     {
@@ -157,8 +153,7 @@ struct FileMap
         }
 
         return rv;
-    }
-    ();
+    }();
 
     public:
     static constexpr size_t FileSepSize = 3;
@@ -174,14 +169,14 @@ struct FileMap
             const int boardPos = ConvertToReversedPos(msb);
             const int startpos = boardPos % 8;
             rv[msb]            = {
-                           startpos > 0 ? GenMask(startpos - 1, Board::BitBoardFields, 8) : 0,
+                startpos > 0 ? GenMask(startpos - 1, Board::BitBoardFields, 8) : 0,
                 GenMask(startpos, Board::BitBoardFields, 8),
-                startpos < 7 ? GenMask(startpos + 1, Board::BitBoardFields, 8) : 0};
+                startpos < 7 ? GenMask(startpos + 1, Board::BitBoardFields, 8) : 0
+            };
         }
 
         return rv;
-    }
-    ();
+    }();
 };
 
 #endif // FILEMAP_H

--- a/include/MoveGeneration/MoveGenerator.h
+++ b/include/MoveGeneration/MoveGenerator.h
@@ -451,8 +451,7 @@ void MoveGenerator::_processFigMoves(
                 return MapT::GetMoves(figPos, fullMap, enemyMap) & ~allyMap;
             if constexpr (isCheck)
                 return MapT::GetMoves(figPos, fullMap, enemyMap) & ~allyMap & allowedMoveSelector;
-        }
-        ();
+        }();
 
         // Performing checks for castlings
         std::bitset<Board::CastlingCount + 1> updatedCastlings = _board.Castlings;

--- a/src/BestMoveSearch.cpp
+++ b/src/BestMoveSearch.cpp
@@ -258,7 +258,8 @@ int BestMoveSearch::_pwsSearch(
     if (depthLeft >= prevSearchRes.GetDepth() || (!wasTTHit && _age - prevSearchRes.GetAge() >= SearchAgeDiffToReplace))
     {
         const TranspositionTable::HashRecord record{
-            zHash, bestMove, bestEval, wasTTHit ? prevSearchRes.GetStatVal() : NO_EVAL, depthLeft, nType, _age};
+            zHash, bestMove, bestEval, wasTTHit ? prevSearchRes.GetStatVal() : NO_EVAL, depthLeft, nType, _age
+        };
         TTable.Add(record, zHash);
     }
 
@@ -353,7 +354,8 @@ BestMoveSearch::_zwSearch(Board &bd, const int alpha, const int depthLeft, uint6
     if (depthLeft >= prevSearchRes.GetDepth() || (!wasTTHit && _age - prevSearchRes.GetAge() >= SearchAgeDiffToReplace))
     {
         const TranspositionTable::HashRecord record{
-            zHash, bestMove, bestEval, wasTTHit ? prevSearchRes.GetStatVal() : NO_EVAL, depthLeft, nType, _age};
+            zHash, bestMove, bestEval, wasTTHit ? prevSearchRes.GetStatVal() : NO_EVAL, depthLeft, nType, _age
+        };
         TTable.Add(record, zHash);
     }
 

--- a/src/BoardEvaluator.cpp
+++ b/src/BoardEvaluator.cpp
@@ -369,8 +369,8 @@ void BoardEvaluator::_evaluateKings(Board &bd, _fieldEvalInfo_t &io)
 
 int32_t BoardEvaluator::_evaluateFields(Board &bd, int32_t phase)
 {
-    static constexpr void (*EvalFunctions[]
-    )(_fieldEvalInfo_t &, Board &, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t
+    static constexpr void (*EvalFunctions[])(
+        _fieldEvalInfo_t &, Board &, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t
     ){_processFigEval<KnightMap, _processKnightEval>, _processFigEval<BishopMap, _processBishopEval>,
       _processFigEval<RookMap, _processRookEval>, _processFigEval<QueenMap, _processQueenEval>};
 

--- a/src/EngineUtils.cpp
+++ b/src/EngineUtils.cpp
@@ -94,7 +94,8 @@ void DisplayBoard(const Board &bd)
     GlobalLogger.StartLogging() << "Moving color: " << (bd.MovingColor == WHITE ? "white" : "black") << std::endl;
     GlobalLogger.StartLogging() << "Possible castlings:\n";
     static constexpr const char *castlingNames[] = {
-        "White King Side", "White Queen Side", "Black King Side", "Black Queen Side"};
+        "White King Side", "White Queen Side", "Black King Side", "Black Queen Side"
+    };
     for (size_t i = 0; i < Board::CastlingCount; ++i)
     {
         GlobalLogger.StartLogging() << castlingNames[i] << ": " << bd.Castlings[i] << std::endl;
@@ -124,7 +125,8 @@ std::pair<uint64_t, uint64_t> ExtractPositionsFromEncoding(const std::string &en
 
     return {
         ExtractPosFromStr(std::toupper(encoding[0]), std::toupper(encoding[1])),
-        ExtractPosFromStr(std::toupper(encoding[2]), std::toupper(encoding[3]))};
+        ExtractPosFromStr(std::toupper(encoding[2]), std::toupper(encoding[3]))
+    };
 }
 
 std::pair<char, char> ConvertToCharPos(const int boardPosMsb)


### PR DESCRIPTION
1. Clang formatted the codebase (again, properly, using the latest clang-format). 
2. Added script for automatic formatting
3. Added workflow that checks if all files are properly formatted

Currently set to clang-format-17 (changable in workflow options)